### PR TITLE
Added a CustomHexdumpBase template, a test case and a Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+hexdumpExample

--- a/Hexdump.hpp
+++ b/Hexdump.hpp
@@ -1,31 +1,43 @@
 #ifndef HEXDUMP_HPP
 #define HEXDUMP_HPP
 
-#include <cctype>
 #include <iomanip>
 #include <ostream>
 
-template <unsigned RowSize, bool ShowAscii>
-struct CustomHexdump
+template <typename T, T RowSize, bool ShowAscii>
+class CustomHexdumpBase
 {
-    CustomHexdump(void* data, unsigned length) :
+public:
+    CustomHexdumpBase(unsigned char* data, T length) :
         mData(static_cast<unsigned char*>(data)), mLength(length) { }
+
+    T getLength() const { return mLength; }
+    unsigned char getData(const T& i) const { return mData[i]; }
+
+private:
     const unsigned char* mData;
-    const unsigned mLength;
+    const T mLength;
 };
 
-template <unsigned RowSize, bool ShowAscii>
-std::ostream& operator<<(std::ostream& out, const CustomHexdump<RowSize, ShowAscii>& dump)
+template <std::size_t RowSize, bool ShowAscii>
+class CustomHexdump : public CustomHexdumpBase<std::size_t, RowSize, ShowAscii>
+{
+public:
+    CustomHexdump(unsigned char* data, std::size_t length) : CustomHexdumpBase<std::size_t, RowSize, ShowAscii>(data, length) {}
+};
+
+template <typename T, T RowSize, bool ShowAscii>
+std::ostream& operator<<(std::ostream& out, const CustomHexdumpBase<T, RowSize, ShowAscii>& dump)
 {
     out.fill('0');
-    for (int i = 0; i < dump.mLength; i += RowSize)
+    for (T i = 0; i < dump.getLength(); i += RowSize)
     {
-        out << "0x" << std::setw(6) << std::hex << i << ": ";
-        for (int j = 0; j < RowSize; ++j)
+        out << "0x" << std::setw(6) << std::hex << int(i) << ": ";
+        for (T j = 0; j < RowSize; ++j)
         {
-            if (i + j < dump.mLength)
+            if (i + j < dump.getLength())
             {
-                out << std::hex << std::setw(2) << static_cast<int>(dump.mData[i + j]) << " ";
+                out << std::hex << std::setw(2) << static_cast<int>(dump.getData(i + j)) << " ";
             }
             else
             {
@@ -36,13 +48,13 @@ std::ostream& operator<<(std::ostream& out, const CustomHexdump<RowSize, ShowAsc
         out << " ";
         if (ShowAscii)
         {
-            for (int j = 0; j < RowSize; ++j)
+            for (T j = 0; j < RowSize; ++j)
             {
-                if (i + j < dump.mLength)
+                if (i + j < dump.getLength())
                 {
-                    if (std::isprint(dump.mData[i + j]))
+                    if (std::isprint(dump.getData(i + j)))
                     {
-                        out << static_cast<char>(dump.mData[i + j]);
+                        out << static_cast<char>(dump.getData(i + j));
                     }
                     else
                     {

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+PROG = hexdumpExample
+
+all: $(PROG)
+
+$(PROG): example.cpp Hexdump.hpp
+	g++ -Wall --pedantic -std=c++14 -o $@ $<
+
+clean:
+	rm -f $(PROG)

--- a/README.md
+++ b/README.md
@@ -36,13 +36,27 @@ This produces the following output:
 
 ## Configuration
 
-Hexdump allows you to configure the length of each row (number of bytes displayed).  Additionally, the ASCII text display can be disabled.  To configure these features, use the `CustomHexdump` class template.  The class accepts two template arguments, the first being the length of the row, and the second being a boolean indicating whether or not the ASCII text should be displayed.
+Hexdump allows you to configure the length of each row (number of
+bytes displayed).  Additionally, the ASCII text display can be
+disabled.  To configure these features, use either one of the
+`CustomHexdump` or `CustomHexdumpBase` class templates.
+
+The `CustomHexdump`class accepts two template arguments, the first
+being the length of the row, and the second being a boolean indicating
+whether or not the ASCII text should be displayed.
+
+The `CustomHexdumpBase`class accepts three template arguments, the first
+being the `type` of the second argument. The second and third
+arguments map to the first and second arguments of `CustomHexdump`.
 
 For example:
 
 ```cpp
-// row length of 8, with ASCII
+// using CustomHexdump, with row length of 8, with ASCII
 std::cout << CustomHexdump<8, true>(data, sizeof(data)) << std::endl;
+
+// or using CustomHexdumpBase, with type uint8_t, row length of 8, with ASCII:
+std::cout << CustomHexdumpBase<uint16_t, 8, true>(data, sizeof(data)) << std::endl;
 ```
 
 Produces:

--- a/example.cpp
+++ b/example.cpp
@@ -2,6 +2,18 @@
 
 #include <iostream>
 
+template <typename T, T RowSize, T bufSize, bool showFlag>
+void testCustomHexdumpBase()
+{
+    unsigned char data[bufSize];
+    unsigned char c = 0;
+    for (auto& val : data)
+    {
+        val = c++;
+    }
+    std::cout << CustomHexdumpBase<T, RowSize, showFlag>(data, bufSize) << std::endl;
+}
+
 int main()
 {
     unsigned char data[150];
@@ -15,4 +27,8 @@ int main()
     std::cout << CustomHexdump<8, true>(data, sizeof(data)) << std::endl;
     std::cout << CustomHexdump<32, false>(data, sizeof(data)) << std::endl;
 
+    testCustomHexdumpBase<uint8_t, 8, 16, true>();
+    testCustomHexdumpBase<int8_t, 8, 16, true>();
+    testCustomHexdumpBase<uint16_t, 16, 32, true>();
+    testCustomHexdumpBase<int16_t, 16, 32, true>();
 }


### PR DESCRIPTION
The CustomHexdump template assumed that we'll be using an unsigned for
the RowSize. With this patch, one can get around this, by specifying
the type in the CustomHexdumpBase template. The patch does not cause
any backwards compatibility problems.