### PR TITLE
Add const to parameter of CustomHexdump

### DIFF
--- a/Hexdump.hpp
+++ b/Hexdump.hpp
@@ -8,8 +8,8 @@
 template <unsigned RowSize, bool ShowAscii>
 struct CustomHexdump
 {
-    CustomHexdump(void* data, unsigned length) :
-        mData(static_cast<unsigned char*>(data)), mLength(length) { }
+    CustomHexdump(const void* data, unsigned length) :
+        mData(static_cast<const unsigned char*>(data)), mLength(length) { }
     const unsigned char* mData;
     const unsigned mLength;
 };


### PR DESCRIPTION
Add `const` to the `data` parameter of CustomHexdump, to prevent compile error for const data.